### PR TITLE
feat: add pain and cost sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,27 +50,35 @@
     </div>
   </section>
 
-<section class="section" id="inside-the-pain">
-  <h2>Inside the pain of launch day.</h2>
-  <ul>
-    <li>Specs get missed and files bounce back</li>
-    <li>Tags break attribution before you even go live</li>
-    <li>Endless rework kills velocity</li>
-    <li>Delay means lost revenue</li>
-  </ul>
-  <blockquote>Without Dataraiils, you don’t just risk delay—you lose the data trail.</blockquote>
-</section>
+  <section id="inside-the-pain" class="pain-section">
+    <div class="pain-wrapper">
+      <h2>SLA: 10–15 days. That’s not a standard. That’s a red flag.</h2>
+      <p>This wasn’t built in a lab. It was built in the middle of live campaigns.</p>
+      <ul>
+        <li><span class="brand-purple">Delay</span> is operational theater</li>
+        <li>Manual rework ≠ process</li>
+        <li>Missed launch = missed revenue</li>
+        <li>Unstructured assets = <span class="brand-purple">unmeasurable</span> campaigns</li>
+      </ul>
+    </div>
+  </section>
 
-<section class="section" id="cost-delay">
-  <h2>Every delay is measurable.</h2>
-  <p>Missing specs don’t just slow you down. They cost you.</p>
-  <ul>
-    <li>10 days delay × $50K/day media plan = $500K</li>
-    <li>2x trafficking rounds = 10 extra PM hours</li>
-    <li>Broken tag = 0% attribution</li>
-  </ul>
-  <a href="#" class="button-secondary">Estimate Your Cost</a>
-</section>
+  <div class="transition">
+    <hr>
+    <p>Here’s what it’s costing you.</p>
+  </div>
+
+  <section id="cost-of-delay" class="cost-section">
+    <div class="cost-wrapper">
+      <h2>Delay isn’t annoying. It’s expensive.</h2>
+      <p>This isn’t theoretical. This is every campaign.</p>
+      <ul class="stats-list">
+        <li><span class="stat">10 days to traffic</span><span class="equals">=</span><span class="desc">lost revenue</span></li>
+        <li><span class="stat">3x trafficking rounds</span><span class="equals">=</span><span class="desc">15 extra PM hours</span></li>
+        <li><span class="stat">Broken tag</span><span class="equals">=</span><span class="desc">0% attribution</span></li>
+      </ul>
+    </div>
+  </section>
 
 <section class="section" id="product">
   <h2>The most expensive 10 yards in creative ops are still manual.</h2>
@@ -89,17 +97,6 @@
     <li>Ops leads fixing files mid-flight</li>
     <li>PMs chasing version control</li>
     <li>No dashboards. No fluff. Just launch.</li>
-  </ul>
-</section>
-
-<section class="section" id="built-from-pain">
-  <h2>We know the SLA is 10–15 days. We also know that’s insane.</h2>
-  <p>This wasn’t built in a lab. It was built in the middle of live campaigns.</p>
-  <ul>
-    <li>Delay is operational theater</li>
-    <li>Manual rework posing as process</li>
-    <li>Delayed launch = delayed revenue</li>
-    <li>Unstructured assets = unmeasurable campaigns</li>
   </ul>
 </section>
 

--- a/style.css
+++ b/style.css
@@ -53,6 +53,73 @@ blockquote {
   text-align: center;
 }
 
+/* Utility */
+.brand-purple {
+  color: #9605DF;
+}
+
+/* Section 1 - Pain */
+.pain-section {
+  background-color: #F5F5F5;
+  padding: 80px 24px;
+}
+.pain-wrapper {
+  max-width: 600px;
+}
+
+/* Transition */
+.transition {
+  text-align: center;
+  padding: 40px 24px;
+}
+.transition hr {
+  border: 0;
+  border-top: 1px solid #9605DF;
+  margin-bottom: 16px;
+}
+.transition p {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+/* Section 2 - Cost */
+.cost-section {
+  background-color: #FAFAFA;
+  padding: 60px 24px;
+}
+.cost-wrapper {
+  max-width: 720px;
+  margin: 0 auto;
+}
+.stats-list {
+  list-style: none;
+  padding: 0;
+  margin: 32px 0 0;
+}
+.stats-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 24px 0;
+  border-bottom: 1px solid #E5E7EB;
+}
+.stats-list li:last-child {
+  border-bottom: none;
+}
+.stat {
+  font-weight: 700;
+  font-size: 24px;
+}
+.desc {
+  font-weight: 400;
+  font-size: 16px;
+}
+.equals {
+  margin: 0 8px;
+  font-weight: 400;
+  font-size: 16px;
+}
+
 /* Nav */
 .nav-bar {
   display: flex;


### PR DESCRIPTION
## Summary
- Introduce "Built from Inside the Pain" section with bullet points highlighting operational issues.
- Add transition divider and new "Cost of Delay" stats block to quantify impact.
- Style new sections with brand colors, spacing, and receipt-style stats layout.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68949578c4f08329a5c5f69495bdda74