### PR TITLE
Implement responsive three-step launch section

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,28 +100,26 @@
   </ul>
 </section>
 
-<section class="three-step-section" id="how-it-works">
+<section class="three-step-process" id="how-it-works">
   <h2 class="section-headline">Three steps. One clean launch.</h2>
   <p class="section-subhead">This isn’t a platform tour. It’s the full handoff—done in three clicks.</p>
 
-  <div class="three-step-process">
-    <div class="step-card">
-      <img src="assets/images/function-ui-icon-upload-asset-dataraiils-purple.png" alt="Upload icon – purple cloud with upward arrow" />
-      <h3>Drop your assets</h3>
-      <p>Upload raw files — any format, from anywhere.</p>
-    </div>
+  <div class="step-card">
+    <img src="assets/images/function-ui-icon-upload-asset-dataraiils-purple.svg" alt="Upload icon – purple cloud with upward arrow" />
+    <h3>Drop your assets</h3>
+    <p>Upload raw files — any format, from anywhere.</p>
+  </div>
 
-    <div class="step-card">
-      <img src="assets/images/function-ui-icon-tag-and-validate-dataraiils-purple.png" alt="Tag and validation icon – purple label with magnifying glass and check mark" />
-      <h3>Dataraiils tags and validates</h3>
-      <p>AI applies naming, specs, and taxonomy — instantly.</p>
-    </div>
+  <div class="step-card">
+    <img src="assets/images/function-ui-icon-tag-and-validate-dataraiils-purple.svg" alt="Tag and validation icon – purple label with magnifying glass and check mark" />
+    <h3>Dataraiils tags and validates</h3>
+    <p>AI applies naming, specs, and taxonomy — instantly.</p>
+  </div>
 
-    <div class="step-card">
-      <img src="assets/images/function-ui-icon-download-package-dataraiils-purple.png" alt="Download icon – purple folder with downward arrow" />
-      <h3>Download your launch pack</h3>
-      <p>Get trafficking sheets, audit logs, and previews — done.</p>
-    </div>
+  <div class="step-card">
+    <img src="assets/images/function-ui-icon-download-package-dataraiils-purple.svg" alt="Download icon – purple folder with downward arrow" />
+    <h3>Download your launch pack</h3>
+    <p>Get trafficking sheets, audit logs, and previews — done.</p>
   </div>
 </section>
 

--- a/style.css
+++ b/style.css
@@ -122,51 +122,52 @@ blockquote {
 
 /* Three Step Process Section */
 .section-headline {
+  width: 100%;
   font-family: 'Inter', sans-serif;
   font-weight: 700;
   font-size: 36px;
-  text-align: center;
-  color: #1B1B1F; /* Navy Ink */
+  color: #1B1B1F;
   margin-bottom: 16px;
 }
 
 .section-subhead {
+  width: 100%;
   font-family: 'Inter', sans-serif;
   font-weight: 400;
   font-size: 18px;
-  text-align: center;
-  color: #4B4B50; /* Slate Fog */
+  color: #4B4B50;
+  margin-bottom: 48px;
   max-width: 600px;
-  margin: 0 auto 48px auto;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .three-step-process {
+  padding: 80px 0;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   gap: 24px;
-  padding: 80px 0;
   flex-wrap: wrap;
+  max-width: 1200px;
+  margin: 0 auto;
+  text-align: center;
 }
 
 .step-card {
   flex: 1 1 30%;
   max-width: 380px;
   padding: 32px;
-  text-align: center;
+  background: transparent;
+  min-height: 320px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: transparent;
-  min-height: 320px;
-  opacity: 0;
-  transform: translateY(20px);
-  transition: all 0.4s ease;
 }
 
 .step-card img {
-  width: 64px;
-  height: 64px;
+  width: 72px;
+  height: 72px;
   object-fit: contain;
   margin-bottom: 24px;
 }
@@ -187,11 +188,6 @@ blockquote {
   max-width: 300px;
 }
 
-.step-card.visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
 @media screen and (max-width: 768px) {
   .three-step-process {
     flex-direction: column;
@@ -201,6 +197,11 @@ blockquote {
   .step-card {
     max-width: 100%;
     margin-bottom: 48px;
+  }
+
+  .step-card img {
+    width: 64px;
+    height: 64px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add "Three steps. One clean launch." section with direct step cards and SVG icons.
- Style three-step section with flexbox layout, centered typography, and responsive icon scaling.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894bc1557208329a12aff5e461146bb