### PR TITLE
feat: add launch-focused testimonial section

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,13 +91,25 @@
   </ul>
 </section>
 
-<section class="section" id="ship">
-  <h2>We didn’t build this for marketers.<br>We built it for the ones who launch at 11:59 PM.</h2>
-  <ul>
-    <li>Ops leads fixing files mid-flight</li>
-    <li>PMs chasing version control</li>
-    <li>No dashboards. No fluff. Just launch.</li>
-  </ul>
+<section class="section launch-section" id="ship">
+  <div class="launch-wrapper">
+    <div class="launch-copy">
+      <h2>We didn’t build this for marketers.</h2>
+      <p>
+        We built it for the ones launching at 11:59 PM.<br>
+        The ones renaming files mid-flight.<br>
+        Manually updating spec sheets. Again.<br>
+        No dashboards. No fluff. Just launch.
+      </p>
+    </div>
+    <div class="launch-quote">
+      <div class="quote-bg" aria-hidden="true" role="presentation"></div>
+      <div class="quote-card">
+        <p>“This saved us 15 hours per campaign. And 15 headaches.”</p>
+        <p class="quote-attribution">— Senior Ad Ops Lead, Top 10 Pharma Agency</p>
+      </div>
+    </div>
+  </div>
 </section>
 
 <section class="three-step-section" id="how-it-works">

--- a/style.css
+++ b/style.css
@@ -120,6 +120,72 @@ blockquote {
   font-size: 16px;
 }
 
+/* Launch Section */
+.launch-section {
+  background-color: #FAFAFA;
+}
+.launch-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 40px;
+}
+.launch-copy {
+  flex: 1 1 50%;
+  max-width: 600px;
+}
+.launch-copy h2 {
+  font-size: 36px;
+  font-weight: 700;
+  color: #1B1B1F; /* Navy Ink */
+  margin-bottom: 16px;
+}
+.launch-copy p {
+  font-size: 18px;
+  font-weight: 400;
+  color: #6B7280; /* Slate Fog */
+  line-height: 1.6;
+}
+.launch-quote {
+  flex: 1 1 50%;
+  position: relative;
+  min-height: 320px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.quote-bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: url('assets/images/dataraiils-app-ui-preview.png');
+  background-size: cover;
+  background-position: center;
+  filter: blur(6px);
+}
+.quote-card {
+  background: rgba(255, 255, 255, 0.85);
+  border-left: 4px solid #6D2EFF; /* Brand Purple */
+  padding: 24px;
+  max-width: 480px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+  position: relative;
+  z-index: 1;
+}
+.quote-card p {
+  font-size: 20px;
+  font-weight: 700;
+  color: #1B1B1F;
+}
+.quote-card .quote-attribution {
+  font-size: 14px;
+  font-weight: 400;
+  color: #6B7280;
+  margin-top: 8px;
+}
+
 /* Three Step Process Section */
 .section-headline {
   font-family: 'Inter', sans-serif;
@@ -407,6 +473,17 @@ footer {
     .hero-cta .button-secondary {
       width: 100%;
       margin-left: 0;
+    }
+    .launch-wrapper {
+      flex-direction: column-reverse;
+    }
+    .launch-copy,
+    .launch-quote {
+      flex: 1 1 100%;
+      max-width: 100%;
+    }
+    .launch-quote {
+      min-height: 240px;
     }
     .nav-bar {
       flex-direction: row;


### PR DESCRIPTION
## Summary
- highlight operational launch messaging with new dedicated section
- add testimonial quote card over blurred UI image
- ensure responsive layout stacks quote and copy for mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894bcef943c8329a00ea74300157343