### PR TITLE
Remove manual creative ops section

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,17 +80,6 @@
     </div>
   </section>
 
-<section class="section" id="product">
-  <h2>The most expensive 10 yards in creative ops are still manual.</h2>
-  <ul>
-    <li>Upload raw assets</li>
-    <li>AI auto-tags and scans</li>
-    <li>Validate naming, specs, and taxonomy</li>
-    <li>Generate trafficking sheet</li>
-    <li>Export. Archive. Launch.</li>
-  </ul>
-</section>
-
 <section class="section launch-section" id="ship">
   <div class="launch-wrapper">
     <div class="launch-copy">


### PR DESCRIPTION
## Summary
- remove manual creative-ops bullet list from homepage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c96a42cc83299162debd26f4c1c8