### PR TITLE
Remove contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
   <a href="#inside-the-pain" class="nav-link">Inside the Pain</a>
   <a href="#proof" class="nav-link">Proof</a>
   <a href="#faq" class="nav-link">FAQ</a>
-  <a href="#contact" class="nav-link">Contact</a>
   <a href="#demo" class="button-primary">Fix Trafficking</a>
 </div>
 
@@ -253,16 +252,6 @@
   <a href="#" class="button-secondary">Start Using Dataraiils</a>
 </section>
 
-<section class="section" id="contact">
-  <h2>Contact Us</h2>
-  <form action="mailto:hello@dataraiils.ai" method="post" enctype="text/plain">
-    <label>Name<br><input type="text" name="name" required></label><br>
-    <label>Email<br><input type="email" name="email" required></label><br>
-    <label>Message<br><textarea name="message" rows="4" required></textarea></label><br>
-    <button type="submit" class="button-primary">Send</button>
-  </form>
-</section>
-
 <footer class="site-footer">
   <div class="footer-grid">
     <div class="footer-left">
@@ -275,7 +264,6 @@
       <a href="#inside-the-pain">Inside the Pain</a>
       <a href="#proof">Proof</a>
       <a href="#faq">FAQ</a>
-      <a href="#contact">Contact</a>
     </nav>
     <div class="footer-legal">
       <p>© 2025 dataraiils.ai</p>


### PR DESCRIPTION
## Summary
- remove the Contact Us form section from the site
- drop navigation links pointing to the removed section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894e2b494ec8329a0942c0a878b1060