### PR TITLE
Refine navigation and typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,29 +8,25 @@
   <meta name="description" content="Dataraiils automates the final mile of creative operations—auto-tagging, validating, and packaging ad assets for flawless campaign launches.">
   <link rel="stylesheet" href="style.css">
   <link rel="icon" href="assets/images/favicon-dataraiils.png">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
-
 <header class="nav-bar">
   <div class="logo">
     <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo" style="height: 32px;">
   </div>
   <button id="nav-toggle" aria-label="Toggle navigation">☰</button>
-  <nav>
-<div id="nav-menu">
-  <a href="#product" class="nav-link">Product</a>
-  <a href="#how-it-works" class="nav-link">How It Works</a>
-  <a href="#inside-the-pain" class="nav-link">Inside the Pain</a>
-  <a href="#proof" class="nav-link">Proof</a>
-  <a href="#faq" class="nav-link">FAQ</a>
-  <a href="#demo" class="button-primary">Fix Trafficking</a>
-</div>
-
+  <nav id="nav-menu">
+    <a href="#product" class="nav-link">Product</a>
+    <a href="#use-cases" class="nav-link">Use Cases</a>
+    <a href="#about" class="nav-link">About</a>
+    <a href="#demo" class="button-primary">Book Demo</a>
   </nav>
 </header>
 
-  <section class="hero">
+<main class="layout-grid">
+
+  <section class="hero" id="product">
     <img
       src="assets/images/dataraiils-ai-trafficking-automation-hero-sailboat-calm-clarity.png"
       alt="Sailboat in motion, symbolizing streamlined execution"
@@ -79,7 +75,7 @@
     </div>
   </section>
 
-<section class="three-step-process" id="how-it-works">
+<section class="three-step-process section" id="use-cases">
   <h2 class="section-headline">Three steps. One clean launch.</h2>
   <p class="section-subhead">This isn’t a platform tour. It’s the full handoff—done in three clicks.</p>
 
@@ -102,7 +98,7 @@
   </div>
 </section>
 
-<section class="section launch-section" id="ship">
+<section class="section launch-section" id="about">
   <div class="launch-wrapper">
     <div class="launch-copy">
       <h2>Campaigns don’t wait. Neither does Dataraiils.</h2>
@@ -252,6 +248,8 @@
   <a href="#" class="button-secondary">Start Using Dataraiils</a>
 </section>
 
+</main>
+
 <footer class="site-footer">
   <div class="footer-grid">
     <div class="footer-left">
@@ -260,18 +258,18 @@
     </div>
     <nav class="footer-nav">
       <a href="#product">Product</a>
-      <a href="#how-it-works">How It Works</a>
-      <a href="#inside-the-pain">Inside the Pain</a>
-      <a href="#proof">Proof</a>
-      <a href="#faq">FAQ</a>
+      <a href="#use-cases">Use Cases</a>
+      <a href="#about">About</a>
+      <a href="#demo">Book Demo</a>
     </nav>
-    <div class="footer-legal">
+  <div class="footer-legal">
       <p>© 2025 dataraiils.ai</p>
       <a href="privacy.html">Privacy</a>
       <a href="terms.html">Terms</a>
       <a href="https://www.linkedin.com/company/dataraiils" target="_blank" rel="noopener">LinkedIn</a>
     </div>
   </div>
+
 </footer>
 
 <script>

--- a/privacy.html
+++ b/privacy.html
@@ -4,23 +4,49 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy – dataraiils.ai</title>
+  <link rel="stylesheet" href="style.css" />
   <link rel="icon" href="assets/images/favicon-dataraiils.png" type="image/png" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
-<body class="bg-white text-gray-900 font-sans">
-  <main class="max-w-3xl mx-auto py-20 px-6">
-    <h1 class="text-4xl font-bold mb-6 text-purple-600">Privacy Policy</h1>
-    <p class="text-gray-700 mb-6">Effective date: July 27, 2025</p>
+<body>
 
-    <p class="text-gray-700 mb-4">dataraiils.ai does not store any creative files. Files are processed temporarily and automatically deleted upon completion. We do not collect personal data from uploaded assets.</p>
+<header class="nav-bar">
+  <div class="logo">
+    <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo" style="height: 32px;">
+  </div>
+  <button id="nav-toggle" aria-label="Toggle navigation">☰</button>
+  <nav id="nav-menu">
+    <a href="index.html#product" class="nav-link">Product</a>
+    <a href="index.html#use-cases" class="nav-link">Use Cases</a>
+    <a href="index.html#about" class="nav-link">About</a>
+    <a href="index.html#demo" class="button-primary">Book Demo</a>
+  </nav>
+</header>
 
-    <p class="text-gray-700 mb-4">We do not sell, rent, or share any data with third parties. Data processed during AI analysis is held in memory only for the duration of the session and not logged or reused.</p>
+<main class="layout-grid">
+  <section class="section">
+    <h1>Privacy Policy</h1>
+    <p>Effective date: July 27, 2025</p>
 
-    <p class="text-gray-700 mb-4">This site uses analytics solely to understand product usage patterns in aggregate, not to track individuals. Any data collected is anonymized.</p>
+    <p>dataraiils.ai does not store any creative files. Files are processed temporarily and automatically deleted upon completion. We do not collect personal data from uploaded assets.</p>
 
-    <p class="text-gray-700 mb-4">By using this site, you agree to this policy. Updates will be posted to this page.</p>
+    <p>We do not sell, rent, or share any data with third parties. Data processed during AI analysis is held in memory only for the duration of the session and not logged or reused.</p>
 
-    <p class="text-gray-700">If you have questions, please contact us at <a href="mailto:privacy@dataraiils.ai" class="text-purple-600 hover:underline">privacy@dataraiils.ai</a>.</p>
-  </main>
+    <p>This site uses analytics solely to understand product usage patterns in aggregate, not to track individuals. Any data collected is anonymized.</p>
+
+    <p>By using this site, you agree to this policy. Updates will be posted to this page.</p>
+
+    <p>If you have questions, please contact us at <a href="mailto:privacy@dataraiils.ai">privacy@dataraiils.ai</a>.</p>
+  </section>
+</main>
+
+<script>
+  const navToggle = document.getElementById('nav-toggle');
+  const navMenu = document.getElementById('nav-menu');
+  navToggle.addEventListener('click', () => {
+    navMenu.classList.toggle('open');
+  });
+</script>
+
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -18,15 +18,26 @@ body {
 h1 {
   font-size: 48px;
   font-weight: 700;
-  margin-bottom: 24px;
+  line-height: 1.2;
+  margin-bottom: 32px;
+  max-width: 72ch;
 }
 h2 {
   font-size: 32px;
   font-weight: 600;
-  margin-bottom: 16px;
+  line-height: 1.3;
+  margin-bottom: 24px;
+  max-width: 72ch;
 }
-p, li {
+p {
   font-size: 16px;
+  line-height: 1.6;
+  margin-bottom: 24px;
+  max-width: 72ch;
+}
+li {
+  font-size: 16px;
+  line-height: 1.6;
 }
 ul, ol {
   margin-left: 20px;
@@ -41,14 +52,27 @@ blockquote {
 }
 
 /* Layout Containers */
-.container {
+:root {
+  --gutter: 16px;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  column-gap: var(--gutter);
+  row-gap: 80px;
   max-width: 1280px;
   margin: 0 auto;
-  padding: 0 24px;
+  padding: 0 var(--gutter);
 }
+.layout-grid > * {
+  grid-column: 1 / -1;
+}
+
 .section {
-  padding: 80px 24px;
+  padding: 80px 0;
 }
+
 .text-center {
   text-align: center;
 }
@@ -56,6 +80,25 @@ blockquote {
 /* Utility */
 .brand-purple {
   color: #9605DF;
+}
+
+/* Navigation */
+.nav-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px var(--gutter);
+  background-color: #fff;
+  border-bottom: 1px solid #eee;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+.nav-link {
+  margin-left: 20px;
+  color: #1B1B1F;
+  text-decoration: none;
+  font-weight: 500;
 }
 
 /* Section 1 - Pain */
@@ -338,21 +381,6 @@ blockquote {
 }
 
 /* Nav */
-.nav-bar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 20px 24px;
-  background-color: #fff;
-  border-bottom: 1px solid #eee;
-}
-.nav-link {
-  margin-left: 20px;
-  color: #1B1B1F;
-  text-decoration: none;
-  font-weight: 500;
-}
-
 #nav-toggle {
   display: none;
   background: none;

--- a/terms.html
+++ b/terms.html
@@ -4,23 +4,49 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Terms of Use – dataraiils.ai</title>
+  <link rel="stylesheet" href="style.css" />
   <link rel="icon" href="assets/images/favicon-dataraiils.png" type="image/png" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
-<body class="bg-white text-gray-900 font-sans">
-  <main class="max-w-3xl mx-auto py-20 px-6">
-    <h1 class="text-4xl font-bold mb-6 text-purple-600">Terms of Use</h1>
-    <p class="text-gray-700 mb-6">Effective date: July 27, 2025</p>
+<body>
 
-    <p class="text-gray-700 mb-4">By accessing and using dataraiils.ai, you agree to these Terms of Use. If you do not agree, do not use the platform.</p>
+<header class="nav-bar">
+  <div class="logo">
+    <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo" style="height: 32px;">
+  </div>
+  <button id="nav-toggle" aria-label="Toggle navigation">☰</button>
+  <nav id="nav-menu">
+    <a href="index.html#product" class="nav-link">Product</a>
+    <a href="index.html#use-cases" class="nav-link">Use Cases</a>
+    <a href="index.html#about" class="nav-link">About</a>
+    <a href="index.html#demo" class="button-primary">Book Demo</a>
+  </nav>
+</header>
 
-    <p class="text-gray-700 mb-4">dataraiils.ai is provided as-is without any warranties. We do not guarantee uninterrupted availability or the accuracy of AI-generated outputs.</p>
+<main class="layout-grid">
+  <section class="section">
+    <h1>Terms of Use</h1>
+    <p>Effective date: July 27, 2025</p>
 
-    <p class="text-gray-700 mb-4">You may not use the site to upload unlawful, offensive, or confidential materials. You retain ownership of all files uploaded, but grant us temporary rights to process them using AI.</p>
+    <p>By accessing and using dataraiils.ai, you agree to these Terms of Use. If you do not agree, do not use the platform.</p>
 
-    <p class="text-gray-700 mb-4">We reserve the right to modify these terms at any time. Changes will be posted to this page with an updated effective date.</p>
+    <p>dataraiils.ai is provided as-is without any warranties. We do not guarantee uninterrupted availability or the accuracy of AI-generated outputs.</p>
 
-    <p class="text-gray-700">For questions, contact <a href="mailto:legal@dataraiils.ai" class="text-purple-600 hover:underline">legal@dataraiils.ai</a>.</p>
-  </main>
+    <p>You may not use the site to upload unlawful, offensive, or confidential materials. You retain ownership of all files uploaded, but grant us temporary rights to process them using AI.</p>
+
+    <p>We reserve the right to modify these terms at any time. Changes will be posted to this page with an updated effective date.</p>
+
+    <p>For questions, contact <a href="mailto:legal@dataraiils.ai">legal@dataraiils.ai</a>.</p>
+  </section>
+</main>
+
+<script>
+  const navToggle = document.getElementById('nav-toggle');
+  const navMenu = document.getElementById('nav-menu');
+  navToggle.addEventListener('click', () => {
+    navMenu.classList.toggle('open');
+  });
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Simplify navigation and make it sticky with a Book Demo call to action
- Introduce a 12-column grid, tighter gutters, and consistent vertical spacing
- Standardize typography across pages with Inter font and defined type scale

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f18e6ff083298e5d41626bcc82ee