### PR TITLE
Animate FAQ answers using max-height transitions

### DIFF
--- a/style.css
+++ b/style.css
@@ -610,12 +610,14 @@ blockquote {
   transition: transform 0.3s ease;
 }
 .faq-answer {
-  display: none;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
   margin-top: 8px;
   font-size: 16px;
 }
 .faq-item.open .faq-answer {
-  display: block;
+  max-height: 500px;
 }
 .faq-item.open .faq-icon {
   transform: rotate(180deg);


### PR DESCRIPTION
## Summary
- Transition FAQ answers using `max-height` to enable smooth expand/collapse animations.
- Limit open answers to a maximum height of 500px.

## Testing
- `node - <<'NODE'
const item = {open:false, classList:{toggle:function(cls){this._open = !this._open; item.open = this._open;}}};
const btn = {parentElement:item, attrs:{'aria-expanded':'false'}, setAttribute:function(name,val){this.attrs[name]=String(val);}, getAttribute:function(name){return this.attrs[name];}};
function handler(){
  const item = btn.parentElement;
  item.classList.toggle('open');
  const expanded = btn.getAttribute('aria-expanded') === 'true';
  btn.setAttribute('aria-expanded', !expanded);
}
console.log('Initial:', item.open, btn.getAttribute('aria-expanded'));
handler();
console.log('After 1st click:', item.open, btn.getAttribute('aria-expanded'));
handler();
console.log('After 2nd click:', item.open, btn.getAttribute('aria-expanded'));
NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fdd50c988329b847d1ccf3bdd566