### PR TITLE
Add footer links to privacy and terms pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,6 +305,8 @@
       <a href="#use-cases">Use Cases</a>
       <a href="#about">About</a>
       <a href="#demo">Book Demo</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="terms.html">Terms</a>
     </nav>
   </div>
 </footer>

--- a/privacy.html
+++ b/privacy.html
@@ -48,6 +48,8 @@
       <a href="index.html#use-cases">Use Cases</a>
       <a href="index.html#about">About</a>
       <a href="index.html#demo">Book Demo</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="terms.html">Terms</a>
     </nav>
   </div>
 </footer>

--- a/terms.html
+++ b/terms.html
@@ -48,6 +48,8 @@
       <a href="index.html#use-cases">Use Cases</a>
       <a href="index.html#about">About</a>
       <a href="index.html#demo">Book Demo</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="terms.html">Terms</a>
     </nav>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- Add Privacy and Terms links to footer navigation on landing page.
- Extend footer navigation on Privacy and Terms pages with links to each other.

## Testing
- `curl -s http://localhost:8000/index.html | grep -n "privacy.html"`
- `curl -I http://localhost:8000/privacy.html`
- `curl -I http://localhost:8000/terms.html`


------
https://chatgpt.com/codex/tasks/task_e_6895134d73d483299cea720986d60455