### PR TITLE
Refine layout spacing and CTA styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,8 +299,8 @@
   <h2>You fixed media. You nailed measurement. But launch is still chaos.</h2>
   <p>The spreadsheet’s still winning. Dataraiils ends that.</p>
   <a href="#demo" class="button-primary">Book a Demo — Go Live in 2 Days</a>
-  <a class="button-secondary" role="button" tabindex="0">Talk to Product</a>
-  <a class="button-secondary" role="button" tabindex="0">Start Using Dataraiils</a>
+  <a class="button-primary" role="button" tabindex="0">Talk to Product</a>
+  <a class="button-primary" role="button" tabindex="0">Start Using Dataraiils</a>
 </section>
 
 </main>
@@ -349,6 +349,15 @@
   const navToggle = document.getElementById('nav-toggle');
   const navMenu = document.getElementById('nav-menu');
   const navLinks = navMenu.querySelectorAll('.nav-link');
+  const navBar = document.querySelector('.nav-bar');
+
+  window.addEventListener('scroll', () => {
+    if (window.scrollY > 10) {
+      navBar.classList.add('scrolled');
+    } else {
+      navBar.classList.remove('scrolled');
+    }
+  });
 
   const focusableSelectors = 'a, button, [tabindex]:not([tabindex="-1"])';
   let firstFocusable, lastFocusable;

--- a/privacy.html
+++ b/privacy.html
@@ -67,8 +67,16 @@
 <script>
   const navToggle = document.getElementById('nav-toggle');
   const navMenu = document.getElementById('nav-menu');
+  const navBar = document.querySelector('.nav-bar');
   navToggle.addEventListener('click', () => {
     navMenu.classList.toggle('open');
+  });
+  window.addEventListener('scroll', () => {
+    if (window.scrollY > 10) {
+      navBar.classList.add('scrolled');
+    } else {
+      navBar.classList.remove('scrolled');
+    }
   });
 </script>
 

--- a/style.css
+++ b/style.css
@@ -22,14 +22,14 @@ body {
   }
 }
 h1 {
-  font-size: 64px;
+  font-size: 48px;
   font-weight: 700;
   line-height: 1.3;
   margin-bottom: 32px;
   max-width: 72ch;
 }
 h2 {
-  font-size: 40px;
+  font-size: 32px;
   font-weight: 600;
   line-height: 1.35;
   margin-bottom: 24px;
@@ -85,6 +85,7 @@ a:not(.button-primary):hover {
 /* Layout Containers */
 :root {
   --gutter: 16px;
+  --section-spacing: 80px;
 
   --color-ink: #1B1B1F;
   --color-muted: #4B5563;
@@ -106,7 +107,7 @@ a:not(.button-primary):hover {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   column-gap: var(--gutter);
-  row-gap: 80px;
+  row-gap: 0;
   max-width: 1280px;
   margin: 0 auto;
   padding: 0 60px;
@@ -115,7 +116,7 @@ a:not(.button-primary):hover {
   grid-column: 1 / -1;
 }
 .section {
-  padding: 120px 0;
+  padding: var(--section-spacing) 0;
   opacity: 0;
   transition: opacity 0.3s ease-out;
 }
@@ -153,6 +154,7 @@ main > section:nth-of-type(even) {
   position: sticky;
   top: 0;
   z-index: 1000;
+  transition: height 0.3s ease, box-shadow 0.3s ease;
 }
 .nav-link {
   margin-left: 20px;
@@ -161,10 +163,15 @@ main > section:nth-of-type(even) {
   font-weight: 500;
 }
 
+.nav-bar.scrolled {
+  height: 48px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
 /* Section 1 - Pain */
 .pain-section {
   background-color: var(--color-bg-muted);
-  padding: 80px 24px;
+  padding: var(--section-spacing) 24px;
 }
 .pain-wrapper {
   max-width: 600px;
@@ -173,7 +180,7 @@ main > section:nth-of-type(even) {
 /* Transition */
 .transition {
   text-align: center;
-  padding: 40px 24px;
+  padding: calc(var(--section-spacing) / 2) 24px;
 }
 .transition hr {
   border: 0;
@@ -188,7 +195,7 @@ main > section:nth-of-type(even) {
 /* Section 2 - Cost */
 .cost-section {
   background-color: var(--color-bg-light);
-  padding: 60px 24px;
+  padding: var(--section-spacing) 24px;
 }
 .cost-wrapper {
   max-width: 720px;
@@ -245,8 +252,8 @@ main > section:nth-of-type(even) {
   max-width: 600px;
 }
 .launch-copy h2 {
-  font-size: 36px;
-  font-weight: 700;
+  font-size: 32px;
+  font-weight: 600;
   color: var(--color-ink); /* Navy Ink */
   margin-bottom: 16px;
 }
@@ -366,8 +373,8 @@ main > section:nth-of-type(even) {
 .section-headline {
   width: 100%;
   font-family: 'Inter', sans-serif;
-  font-weight: 700;
-  font-size: 36px;
+  font-weight: 600;
+  font-size: 32px;
   color: var(--color-ink);
   margin-bottom: 16px;
 }
@@ -386,7 +393,7 @@ main > section:nth-of-type(even) {
 
 .three-steps {
   text-align: center;
-  padding: 64px 24px;
+  padding: var(--section-spacing) 24px;
 }
 
 .steps-grid {
@@ -512,7 +519,8 @@ main > section:nth-of-type(even) {
   cursor: pointer;
   text-decoration: none;
   touch-action: manipulation;
-  transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 }
 
 @media (hover: hover) {
@@ -520,6 +528,7 @@ main > section:nth-of-type(even) {
     background-color: var(--color-brand-dark);
     transform: translateY(-2px);
     text-decoration: none;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   }
 }
 .button-primary:focus {
@@ -530,35 +539,8 @@ main > section:nth-of-type(even) {
 .button-primary:active {
   background-color: var(--color-brand-dark);
   transform: none;
-  transition: background-color 0s, transform 0s;
-}
-.button-secondary {
-  color: #7E04B9;
-  text-decoration: underline;
-}
-.button-secondary {
-  background-color: #9605DF;
-  color: #FFFFFF;
-  padding: 16px 32px;
-  font-size: 16px;
-  font-weight: 500;
-  line-height: 1.2;
-  border: none;
-  border-radius: 999px;
-  cursor: pointer;
-  margin-left: 16px;
-  text-decoration: none;
-  transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
-  display: inline-block;
-}
-.button-secondary:hover {
-  background-color: #7E04B9;
-  box-shadow: 0 0 8px rgba(150, 5, 223, 0.4);
-  transform: scale(1.05);
-}
-.button-secondary:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(150, 5, 223, 0.5);
+  transition: background-color 0s, transform 0s, box-shadow 0s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 /* Hero Section */
@@ -667,13 +649,13 @@ main > section:nth-of-type(even) {
 /* FAQ */
 /* FAQ */
 .faq-section {
-  padding: 120px 0;
+  padding: var(--section-spacing) 0;
   background-color: #F7F7F7;
 }
 
 .faq-heading {
-  font-size: 40px;
-  font-weight: 700;
+  font-size: 32px;
+  font-weight: 600;
   text-align: center;
   margin-bottom: 80px;
   color: var(--color-ink);
@@ -897,8 +879,7 @@ main > section:nth-of-type(even) {
       width: 100%;
       text-align: center;
     }
-    .hero-cta .button-primary,
-    .hero-cta .button-secondary {
+    .hero-cta .button-primary {
       width: 100%;
       margin-left: 0;
     }
@@ -953,10 +934,6 @@ main > section:nth-of-type(even) {
       left: 0;
       width: 100%;
       margin-left: 0;
-    }
-    .button-secondary {
-      display: block;
-      margin: 12px 0 0;
     }
     .footer-grid {
       flex-direction: column;

--- a/terms.html
+++ b/terms.html
@@ -67,8 +67,16 @@
 <script>
   const navToggle = document.getElementById('nav-toggle');
   const navMenu = document.getElementById('nav-menu');
+  const navBar = document.querySelector('.nav-bar');
   navToggle.addEventListener('click', () => {
     navMenu.classList.toggle('open');
+  });
+  window.addEventListener('scroll', () => {
+    if (window.scrollY > 10) {
+      navBar.classList.add('scrolled');
+    } else {
+      navBar.classList.remove('scrolled');
+    }
   });
 </script>
 


### PR DESCRIPTION
## Summary
- standardize vertical rhythm via a section spacing variable, ensuring uniform padding across sections
- align typography hierarchy (48px H1, 32px H2) and emphasize primary CTAs with brand purple styling
- add reduced-state sticky navigation that shrinks on scroll for better usability

## Testing
- `npm test` *(fails: package.json missing)*
- `python3 scripts/contrast_check.py`


------
https://chatgpt.com/codex/tasks/task_e_689742ac9a54832996a576fafd5ca04a