### PR TITLE
Remove hero trails overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,6 @@
       <source src="assets/images/hero-calm_clarity.mp4" type="video/mp4" />
     </video>
     <div class="hero-overlay"></div>
-    <div class="hero-trails"></div>
     <div class="hero-content">
       <h1 class="fade-in">Trafficking shouldn’t suck</h1>
       <p class="lead fade-in delay-1">Built for the people who ship.</p>

--- a/style.css
+++ b/style.css
@@ -592,13 +592,7 @@ main > section:nth-of-type(even) {
   width: 40%;
   height: 20%;
   transform: translateY(-50%);
-  background: repeating-linear-gradient(
-    to right,
-    rgba(150, 5, 223, 0.15) 0px,
-    rgba(150, 5, 223, 0.15) 2px,
-    transparent 2px,
-    transparent 12px
-  );
+  background: none;
   opacity: 0.2;
   z-index: 2;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- Remove hero trails background gradient styling
- Drop obsolete `hero-trails` div from hero section

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974de885388329a32b9bb2b13e0877