### PR TITLE
Ensure sections use inner layout grids with full-bleed backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,28 +26,30 @@
 
 <a href="#demo" class="button-primary persistent-cta">Get Demo</a>
 
-<main class="layout-grid">
+<main>
 
   <section class="hero" id="product">
-    <video
-      class="hero-bg"
-      autoplay
-      muted
-      loop
-      playsinline
-      aria-hidden="true"
-    >
-      <source src="assets/images/hero-calm_clarity.mp4" type="video/mp4" />
-    </video>
-    <div class="hero-overlay"></div>
-    <div class="hero-content">
-      <h1 class="fade-in">Trafficking shouldn’t suck</h1>
-      <p class="lead fade-in delay-1">Auto-tag and validate assets for instant launch.</p>
-      <div class="hero-cta fade-in delay-2">
-        <a href="#demo" class="button-primary">See it in action</a>
+    <div class="layout-grid">
+      <video
+        class="hero-bg"
+        autoplay
+        muted
+        loop
+        playsinline
+        aria-hidden="true"
+      >
+        <source src="assets/images/hero-calm_clarity.mp4" type="video/mp4" />
+      </video>
+      <div class="hero-overlay"></div>
+      <div class="hero-content">
+        <h1 class="fade-in">Trafficking shouldn’t suck</h1>
+        <p class="lead fade-in delay-1">Auto-tag and validate assets for instant launch.</p>
+        <div class="hero-cta fade-in delay-2">
+          <a href="#demo" class="button-primary">See it in action</a>
+        </div>
       </div>
     </div>
-    </section>
+  </section>
 
     <div class="transition">
       <hr>
@@ -55,15 +57,17 @@
     </div>
 
   <section id="inside-the-pain" class="section pain-section">
-    <div class="pain-wrapper">
-      <h2>SLA: 10–15 days. That’s not a standard. That’s a red flag.</h2>
-      <p>This wasn’t built in a lab. It was built in the middle of live campaigns.</p>
-      <ul>
-        <li><span class="brand-purple">Delay</span> is operational theater</li>
-        <li>Manual rework ≠ process</li>
-        <li>Missed launch = missed revenue</li>
-        <li>Unstructured assets = <span class="brand-purple">unmeasurable</span> campaigns</li>
-      </ul>
+    <div class="layout-grid">
+      <div class="pain-wrapper">
+        <h2>SLA: 10–15 days. That’s not a standard. That’s a red flag.</h2>
+        <p>This wasn’t built in a lab. It was built in the middle of live campaigns.</p>
+        <ul>
+          <li><span class="brand-purple">Delay</span> is operational theater</li>
+          <li>Manual rework ≠ process</li>
+          <li>Missed launch = missed revenue</li>
+          <li>Unstructured assets = <span class="brand-purple">unmeasurable</span> campaigns</li>
+        </ul>
+      </div>
     </div>
   </section>
 
@@ -73,60 +77,66 @@
   </div>
 
   <section id="cost-of-delay" class="section cost-section">
-    <div class="cost-wrapper">
-      <h2>Delay isn’t annoying. It’s expensive.</h2>
-      <p>This isn’t theoretical. This is every campaign.</p>
-      <div class="stats-grid">
-        <div class="stats-card">
-          <img src="assets/images/icon-delay.svg" alt="" class="stats-icon" />
-          <div class="stat">10 days to traffic</div>
-          <div class="desc">Lost revenue</div>
-        </div>
-        <div class="stats-card">
-          <img src="assets/images/icon-rounds.svg" alt="" class="stats-icon" />
-          <div class="stat">3x trafficking rounds</div>
-          <div class="desc">15 extra PM hours</div>
-        </div>
-        <div class="stats-card">
-          <img src="assets/images/icon-broken-tag.svg" alt="" class="stats-icon" />
-          <div class="stat">Broken tag</div>
-          <div class="desc">0% attribution</div>
+    <div class="layout-grid">
+      <div class="cost-wrapper">
+        <h2>Delay isn’t annoying. It’s expensive.</h2>
+        <p>This isn’t theoretical. This is every campaign.</p>
+        <div class="stats-grid">
+          <div class="stats-card">
+            <img src="assets/images/icon-delay.svg" alt="" class="stats-icon" />
+            <div class="stat">10 days to traffic</div>
+            <div class="desc">Lost revenue</div>
+          </div>
+          <div class="stats-card">
+            <img src="assets/images/icon-rounds.svg" alt="" class="stats-icon" />
+            <div class="stat">3x trafficking rounds</div>
+            <div class="desc">15 extra PM hours</div>
+          </div>
+          <div class="stats-card">
+            <img src="assets/images/icon-broken-tag.svg" alt="" class="stats-icon" />
+            <div class="stat">Broken tag</div>
+            <div class="desc">0% attribution</div>
+          </div>
         </div>
       </div>
     </div>
   </section>
 
 <section class="three-steps section" id="use-cases">
-  <h2>Three steps. One clean launch.</h2>
-  <p class="subtext">This isn’t a platform tour. It’s the full handoff—done in three clicks.</p>
+  <div class="layout-grid">
+    <h2>Three steps. One clean launch.</h2>
+    <p class="subtext">This isn’t a platform tour. It’s the full handoff—done in three clicks.</p>
 
-  <div class="steps-grid">
-    <div class="step-card">
-      <div class="step-icon" data-step="1"></div>
-      <h3>Drop your assets</h3>
-      <p>Upload raw files — any format, from anywhere.</p>
-    </div>
+    <div class="steps-grid">
+      <div class="step-card">
+        <div class="step-icon" data-step="1"></div>
+        <h3>Drop your assets</h3>
+        <p>Upload raw files — any format, from anywhere.</p>
+      </div>
 
-    <div class="step-card">
-      <div class="step-icon" data-step="2"></div>
-      <h3>Dataraiils tags and validates</h3>
-      <p>AI applies naming, specs, and taxonomy — instantly.</p>
-    </div>
+      <div class="step-card">
+        <div class="step-icon" data-step="2"></div>
+        <h3>Dataraiils tags and validates</h3>
+        <p>AI applies naming, specs, and taxonomy — instantly.</p>
+      </div>
 
-    <div class="step-card">
-      <div class="step-icon" data-step="3"></div>
-      <h3>Download your launch pack</h3>
-      <p>Get trafficking sheets, audit logs, and previews — done.</p>
+      <div class="step-card">
+        <div class="step-icon" data-step="3"></div>
+        <h3>Download your launch pack</h3>
+        <p>Get trafficking sheets, audit logs, and previews — done.</p>
+      </div>
     </div>
   </div>
 </section>
 
 <section id="operator-feedback" class="section testimonials">
-  <h2>Operator feedback</h2>
-  <div class="testimonials-grid">
-    <div class="testimonial">
-      <p>“It just worked. That’s all I needed.”</p>
-      <p class="client">Jamie L., Ad Ops Specialist</p>
+  <div class="layout-grid">
+    <h2>Operator feedback</h2>
+    <div class="testimonials-grid">
+      <div class="testimonial">
+        <p>“It just worked. That’s all I needed.”</p>
+        <p class="client">Jamie L., Ad Ops Specialist</p>
+      </div>
     </div>
   </div>
 </section>

--- a/style.css
+++ b/style.css
@@ -116,6 +116,8 @@ a:not(.button-primary):hover {
   grid-column: 1 / -1;
 }
 .section {
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
   padding: var(--section-spacing) 0;
   opacity: 0;
   transition: opacity 0.3s ease-out;
@@ -189,7 +191,7 @@ body.menu-open .persistent-cta {
 /* Section 1 - Pain */
 .pain-section {
   background-color: var(--color-bg-muted);
-  padding: var(--section-spacing) 24px;
+  padding: var(--section-spacing) 0;
 }
 .pain-wrapper {
   max-width: 600px;
@@ -213,7 +215,7 @@ body.menu-open .persistent-cta {
 /* Section 2 - Cost */
 .cost-section {
   background-color: var(--color-bg-light);
-  padding: var(--section-spacing) 24px;
+  padding: var(--section-spacing) 0;
 }
 .cost-wrapper {
   max-width: 720px;
@@ -411,7 +413,7 @@ body.menu-open .persistent-cta {
 
 .three-steps {
   text-align: center;
-  padding: var(--section-spacing) 24px;
+  padding: var(--section-spacing) 0;
 }
 
 .steps-grid {
@@ -825,7 +827,7 @@ body.menu-open .persistent-cta {
 /* Testimonials */
 .testimonials {
   background-color: #F7F7F7;
-  padding: 100px 24px;
+  padding: 100px 0;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- Remove global grid from `<main>` and wrap key sections in `.layout-grid` for localized alignment
- Expand `.section` to span viewport and strip horizontal padding from sectional variants

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c85903a7483298c3d6d03557e1b07