### PR TITLE
Refine hero layout and spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,18 +29,18 @@
 <main>
 
   <section class="hero" id="product">
+    <video
+      class="hero-bg"
+      autoplay
+      muted
+      loop
+      playsinline
+      aria-hidden="true"
+    >
+      <source src="assets/images/hero-calm_clarity.mp4" type="video/mp4" />
+    </video>
+    <div class="hero-overlay"></div>
     <div class="layout-grid">
-      <video
-        class="hero-bg"
-        autoplay
-        muted
-        loop
-        playsinline
-        aria-hidden="true"
-      >
-        <source src="assets/images/hero-calm_clarity.mp4" type="video/mp4" />
-      </video>
-      <div class="hero-overlay"></div>
       <div class="hero-content">
         <h1 class="fade-in">Trafficking shouldn’t suck</h1>
         <p class="lead fade-in delay-1">Auto-tag and validate assets for instant launch.</p>

--- a/style.css
+++ b/style.css
@@ -616,8 +616,8 @@ body.menu-open .persistent-cta {
   grid-column: 1 / span 6;
   position: relative;
   z-index: 3;
-  max-width: 580px;
-  padding-left: 5vw;
+  max-width: 600px;
+  padding: 120px 60px 160px;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -878,7 +878,7 @@ body.menu-open .persistent-cta {
     }
     .hero-content {
       grid-column: 1;
-      padding: 40px 10vw;
+      padding: 80px 10vw 160px;
       max-width: 100%;
       text-align: center;
       align-items: center;


### PR DESCRIPTION
## Summary
- Move hero background video outside layout grid and keep it behind content
- Constrain hero text width and add ample padding to avoid overlay collisions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a9a7e6208329a0684324ca08aadf